### PR TITLE
Make assertions about bool be const

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ ndarray = "0.12"
 num-traits = "0.2"
 py_literal = "0.2"
 quick-error = "1.2"
+static_assertions = "0.3.1"
 zip = { version = "0.5", default-features = false, optional = true }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ extern crate num_traits;
 extern crate py_literal;
 #[macro_use]
 extern crate quick_error;
+extern crate static_assertions;
 #[cfg(feature = "npz")]
 extern crate zip;
 


### PR DESCRIPTION
This is cleaner and doesn't rely on the compiler performing sufficient const propagation to eliminate the checks at runtime. It also means that `WritableElement` can be implemented for `bool` using the `impl_writable_primitive` macro.