### PR TITLE
Remove unnecessary assertions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ ndarray = "0.12"
 num-traits = "0.2"
 py_literal = "0.2"
 quick-error = "1.2"
-static_assertions = "0.3.1"
 zip = { version = "0.5", default-features = false, optional = true }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,6 @@ extern crate num_traits;
 extern crate py_literal;
 #[macro_use]
 extern crate quick_error;
-extern crate static_assertions;
 #[cfg(feature = "npz")]
 extern crate zip;
 


### PR DESCRIPTION
Rust guarantees that the size and alignment of `bool` is `1`, the bitwise representation of `false` is `0x00`, and the bitwise representation of `true` is `0x01`.