### PR TITLE
Update to new style of Error trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ byteorder = "1.3.2"
 ndarray = "0.12"
 num-traits = "0.2"
 py_literal = "0.2"
-quick-error = "1.2"
 zip = { version = "0.5", default-features = false, optional = true }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,6 @@ extern crate byteorder;
 extern crate ndarray;
 extern crate num_traits;
 extern crate py_literal;
-#[macro_use]
-extern crate quick_error;
 #[cfg(feature = "npz")]
 extern crate zip;
 

--- a/src/npy/header.rs
+++ b/src/npy/header.rs
@@ -69,21 +69,39 @@ impl From<PyValueParseError> for HeaderParseError {
     }
 }
 
-quick_error! {
-    #[derive(Debug)]
-    pub enum HeaderReadError {
-        Io(err: io::Error) {
-            description("I/O error")
-            display(x) -> ("{}: {}", x.description(), err)
-            cause(err)
-            from()
+#[derive(Debug)]
+pub enum HeaderReadError {
+    Io(io::Error),
+    Parse(HeaderParseError),
+}
+
+impl Error for HeaderReadError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            HeaderReadError::Io(err) => Some(err),
+            HeaderReadError::Parse(err) => Some(err),
         }
-        Parse(err: HeaderParseError) {
-            description("error parsing header")
-            display(x) -> ("{}: {}", x.description(), err)
-            cause(err)
-            from()
+    }
+}
+
+impl fmt::Display for HeaderReadError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            HeaderReadError::Io(err) => write!(f, "I/O error: {}", err),
+            HeaderReadError::Parse(err) => write!(f, "error parsing header: {}", err),
         }
+    }
+}
+
+impl From<io::Error> for HeaderReadError {
+    fn from(err: io::Error) -> HeaderReadError {
+        HeaderReadError::Io(err)
+    }
+}
+
+impl From<HeaderParseError> for HeaderReadError {
+    fn from(err: HeaderParseError) -> HeaderReadError {
+        HeaderReadError::Parse(err)
     }
 }
 

--- a/src/npy/header.rs
+++ b/src/npy/header.rs
@@ -176,23 +176,38 @@ impl Version {
     }
 }
 
+#[derive(Debug)]
+pub enum FormatHeaderError {
+    PyValue(PyValueFormatError),
+}
+
+impl Error for FormatHeaderError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            FormatHeaderError::PyValue(err) => Some(err),
+        }
+    }
+}
+
+impl fmt::Display for FormatHeaderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            FormatHeaderError::PyValue(err) => write!(f, "error formatting Python value: {}", err),
+        }
+    }
+}
+
+impl From<PyValueFormatError> for FormatHeaderError {
+    fn from(err: PyValueFormatError) -> FormatHeaderError {
+        FormatHeaderError::PyValue(err)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Header {
     pub type_descriptor: PyValue,
     pub fortran_order: bool,
     pub shape: Vec<usize>,
-}
-
-quick_error! {
-    #[derive(Debug)]
-    pub enum FormatHeaderError {
-        PyValue(err: PyValueFormatError) {
-            description("error formatting Python value")
-            display(x) -> ("{}", x.description())
-            cause(err)
-            from()
-        }
-    }
 }
 
 impl fmt::Display for Header {

--- a/src/npz.rs
+++ b/src/npz.rs
@@ -4,29 +4,48 @@ use crate::{
 use ndarray::prelude::*;
 use ndarray::{Data, DataOwned};
 use std::error::Error;
+use std::fmt;
 use std::io::{Read, Seek, Write};
 use zip::result::ZipError;
 use zip::write::FileOptions;
 use zip::{CompressionMethod, ZipArchive, ZipWriter};
 
-quick_error! {
-    /// An error writing a `.npz` file.
-    #[derive(Debug)]
-    pub enum WriteNpzError {
-        /// An error caused by the zip file.
-        Zip(err: ZipError) {
-            description("zip file error")
-            display(x) -> ("{}: {}", x.description(), err)
-            cause(err)
-            from()
+/// An error writing a `.npz` file.
+#[derive(Debug)]
+pub enum WriteNpzError {
+    /// An error caused by the zip file.
+    Zip(ZipError),
+    /// An error caused by writing an inner `.npy` file.
+    Npy(WriteNpyError),
+}
+
+impl Error for WriteNpzError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            WriteNpzError::Zip(err) => Some(err),
+            WriteNpzError::Npy(err) => Some(err),
         }
-        /// An error caused by writing an inner `.npy` file.
-        Npy(err: WriteNpyError) {
-            description("error writing npy file to npz archive")
-            display(x) -> ("{}: {}", x.description(), err)
-            cause(err)
-            from()
+    }
+}
+
+impl fmt::Display for WriteNpzError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            WriteNpzError::Zip(err) => write!(f, "zip file error: {}", err),
+            WriteNpzError::Npy(err) => write!(f, "error writing npy file to npz archive: {}", err),
         }
+    }
+}
+
+impl From<ZipError> for WriteNpzError {
+    fn from(err: ZipError) -> WriteNpzError {
+        WriteNpzError::Zip(err)
+    }
+}
+
+impl From<WriteNpyError> for WriteNpzError {
+    fn from(err: WriteNpyError) -> WriteNpzError {
+        WriteNpzError::Npy(err)
     }
 }
 


### PR DESCRIPTION
This removes the dependency on `quick-error` and updates to the new style of the `Error` trait (i.e. the `source` method and no `description` implementation).