### PR TITLE
Bump minimum Rust version to 1.37

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
       - libssl-dev
 cache: cargo
 rust:
-  - 1.32.0
+  - 1.37.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
This should fix the failing Travis CI builds.