### PR TITLE
Refactor error types

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,7 +2,7 @@ extern crate ndarray;
 extern crate ndarray_npy;
 
 use ndarray::prelude::*;
-use ndarray_npy::{ReadNpyExt, WriteNpyError, WriteNpyExt};
+use ndarray_npy::{ReadNpyError, ReadNpyExt, WriteNpyError, WriteNpyExt};
 use std::fs::File;
 
 fn write_example() -> Result<(), WriteNpyError> {
@@ -12,7 +12,7 @@ fn write_example() -> Result<(), WriteNpyError> {
     Ok(())
 }
 
-fn read_example() -> Result<(), Box<dyn std::error::Error>> {
+fn read_example() -> Result<(), ReadNpyError> {
     let reader = File::open("array.npy")?;
     let arr = Array2::<i32>::read_npy(reader)?;
     println!("arr =\n{}", arr);

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,4 @@
-extern crate ndarray;
-extern crate ndarray_npy;
-
-use ndarray::prelude::*;
+use ndarray::{array, Array2};
 use ndarray_npy::{ReadNpyError, ReadNpyExt, WriteNpyError, WriteNpyExt};
 use std::fs::File;
 

--- a/examples/simple_npz.rs
+++ b/examples/simple_npz.rs
@@ -1,7 +1,4 @@
-extern crate ndarray;
-extern crate ndarray_npy;
-
-use ndarray::prelude::*;
+use ndarray::{array, Array1, Array2};
 use ndarray_npy::{NpzReader, NpzWriter};
 use std::fs::File;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,8 @@ mod npy;
 mod npz;
 
 pub use crate::npy::{
-    ReadElementsError, ReadNpyError, ReadNpyExt, ReadableElement, WritableElement,
-    WriteElementsError, WriteNpyError, WriteNpyExt,
+    ReadDataError, ReadNpyError, ReadNpyExt, ReadableElement, WritableElement, WriteDataError,
+    WriteNpyError, WriteNpyExt,
 };
 #[cfg(feature = "npz")]
 pub use crate::npz::{NpzReader, NpzWriter, ReadNpzError, WriteNpzError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,13 +34,6 @@
 //!
 //! [header dictionary]: https://docs.scipy.org/doc/numpy/reference/generated/numpy.lib.format.html#format-version-1-0
 
-extern crate byteorder;
-extern crate ndarray;
-extern crate num_traits;
-extern crate py_literal;
-#[cfg(feature = "npz")]
-extern crate zip;
-
 mod npy;
 #[cfg(feature = "npz")]
 mod npz;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,8 @@ mod npy;
 mod npz;
 
 pub use crate::npy::{
-    ReadNpyError, ReadNpyExt, ReadableElement, WritableElement, WriteNpyError, WriteNpyExt,
+    ReadElementsError, ReadNpyError, ReadNpyExt, ReadableElement, WritableElement,
+    WriteElementsError, WriteNpyError, WriteNpyExt,
 };
 #[cfg(feature = "npz")]
 pub use crate::npz::{NpzReader, NpzWriter, ReadNpzError, WriteNpzError};

--- a/src/npy/header.rs
+++ b/src/npy/header.rs
@@ -11,7 +11,7 @@ use std::io;
 const MAGIC_STRING: &[u8] = b"\x93NUMPY";
 
 #[derive(Debug)]
-pub enum HeaderParseError {
+pub enum ParseHeaderError {
     MagicString,
     Version { major: u8, minor: u8 },
     NonAscii,
@@ -23,9 +23,9 @@ pub enum HeaderParseError {
     MissingNewline,
 }
 
-impl Error for HeaderParseError {
+impl Error for ParseHeaderError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use HeaderParseError::*;
+        use ParseHeaderError::*;
         match self {
             MagicString => None,
             Version { .. } => None,
@@ -40,9 +40,9 @@ impl Error for HeaderParseError {
     }
 }
 
-impl fmt::Display for HeaderParseError {
+impl fmt::Display for ParseHeaderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use HeaderParseError::*;
+        use ParseHeaderError::*;
         match self {
             MagicString => write!(f, "start does not match magic string"),
             Version { major, minor } => write!(f, "unknown version number: {}.{}", major, minor),
@@ -57,51 +57,51 @@ impl fmt::Display for HeaderParseError {
     }
 }
 
-impl From<std::str::Utf8Error> for HeaderParseError {
-    fn from(_: std::str::Utf8Error) -> HeaderParseError {
-        HeaderParseError::NonAscii
+impl From<std::str::Utf8Error> for ParseHeaderError {
+    fn from(_: std::str::Utf8Error) -> ParseHeaderError {
+        ParseHeaderError::NonAscii
     }
 }
 
-impl From<PyValueParseError> for HeaderParseError {
-    fn from(err: PyValueParseError) -> HeaderParseError {
-        HeaderParseError::DictParse(err)
+impl From<PyValueParseError> for ParseHeaderError {
+    fn from(err: PyValueParseError) -> ParseHeaderError {
+        ParseHeaderError::DictParse(err)
     }
 }
 
 #[derive(Debug)]
-pub enum HeaderReadError {
+pub enum ReadHeaderError {
     Io(io::Error),
-    Parse(HeaderParseError),
+    Parse(ParseHeaderError),
 }
 
-impl Error for HeaderReadError {
+impl Error for ReadHeaderError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            HeaderReadError::Io(err) => Some(err),
-            HeaderReadError::Parse(err) => Some(err),
+            ReadHeaderError::Io(err) => Some(err),
+            ReadHeaderError::Parse(err) => Some(err),
         }
     }
 }
 
-impl fmt::Display for HeaderReadError {
+impl fmt::Display for ReadHeaderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            HeaderReadError::Io(err) => write!(f, "I/O error: {}", err),
-            HeaderReadError::Parse(err) => write!(f, "error parsing header: {}", err),
+            ReadHeaderError::Io(err) => write!(f, "I/O error: {}", err),
+            ReadHeaderError::Parse(err) => write!(f, "error parsing header: {}", err),
         }
     }
 }
 
-impl From<io::Error> for HeaderReadError {
-    fn from(err: io::Error) -> HeaderReadError {
-        HeaderReadError::Io(err)
+impl From<io::Error> for ReadHeaderError {
+    fn from(err: io::Error) -> ReadHeaderError {
+        ReadHeaderError::Io(err)
     }
 }
 
-impl From<HeaderParseError> for HeaderReadError {
-    fn from(err: HeaderParseError) -> HeaderReadError {
-        HeaderReadError::Parse(err)
+impl From<ParseHeaderError> for ReadHeaderError {
+    fn from(err: ParseHeaderError) -> ReadHeaderError {
+        ReadHeaderError::Parse(err)
     }
 }
 
@@ -116,12 +116,12 @@ impl Version {
     /// byte for minor version).
     const VERSION_NUM_BYTES: usize = 2;
 
-    fn from_bytes(bytes: &[u8]) -> Result<Self, HeaderParseError> {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, ParseHeaderError> {
         debug_assert_eq!(bytes.len(), Self::VERSION_NUM_BYTES);
         match (bytes[0], bytes[1]) {
             (0x01, 0x00) => Ok(Version::V1_0),
             (0x02, 0x00) => Ok(Version::V2_0),
-            (major, minor) => Err(HeaderParseError::Version { major, minor }),
+            (major, minor) => Err(ParseHeaderError::Version { major, minor }),
         }
     }
 
@@ -204,38 +204,38 @@ impl From<PyValueFormatError> for FormatHeaderError {
 }
 
 #[derive(Debug)]
-pub enum HeaderWriteError {
+pub enum WriteHeaderError {
     Io(io::Error),
     Format(FormatHeaderError),
 }
 
-impl Error for HeaderWriteError {
+impl Error for WriteHeaderError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            HeaderWriteError::Io(err) => Some(err),
-            HeaderWriteError::Format(err) => Some(err),
+            WriteHeaderError::Io(err) => Some(err),
+            WriteHeaderError::Format(err) => Some(err),
         }
     }
 }
 
-impl fmt::Display for HeaderWriteError {
+impl fmt::Display for WriteHeaderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            HeaderWriteError::Io(err) => write!(f, "I/O error: {}", err),
-            HeaderWriteError::Format(err) => write!(f, "error formatting header: {}", err),
+            WriteHeaderError::Io(err) => write!(f, "I/O error: {}", err),
+            WriteHeaderError::Format(err) => write!(f, "error formatting header: {}", err),
         }
     }
 }
 
-impl From<io::Error> for HeaderWriteError {
-    fn from(err: io::Error) -> HeaderWriteError {
-        HeaderWriteError::Io(err)
+impl From<io::Error> for WriteHeaderError {
+    fn from(err: io::Error) -> WriteHeaderError {
+        WriteHeaderError::Io(err)
     }
 }
 
-impl From<FormatHeaderError> for HeaderWriteError {
-    fn from(err: FormatHeaderError) -> HeaderWriteError {
-        HeaderWriteError::Format(err)
+impl From<FormatHeaderError> for WriteHeaderError {
+    fn from(err: FormatHeaderError) -> WriteHeaderError {
+        WriteHeaderError::Format(err)
     }
 }
 
@@ -253,7 +253,7 @@ impl fmt::Display for Header {
 }
 
 impl Header {
-    fn from_py_value(value: PyValue) -> Result<Self, HeaderParseError> {
+    fn from_py_value(value: PyValue) -> Result<Self, ParseHeaderError> {
         if let PyValue::Dict(dict) = value {
             let mut type_descriptor: Option<PyValue> = None;
             let mut fortran_order: Option<bool> = None;
@@ -267,7 +267,7 @@ impl Header {
                         if let PyValue::Boolean(b) = value {
                             fortran_order = Some(b);
                         } else {
-                            return Err(HeaderParseError::IllegalValue {
+                            return Err(ParseHeaderError::IllegalValue {
                                 key: "fortran_order".to_owned(),
                                 value,
                             });
@@ -284,13 +284,13 @@ impl Header {
                         if let Some(s) = parse_shape(&value) {
                             shape = Some(s);
                         } else {
-                            return Err(HeaderParseError::IllegalValue {
+                            return Err(ParseHeaderError::IllegalValue {
                                 key: "shape".to_owned(),
                                 value,
                             });
                         }
                     }
-                    k => return Err(HeaderParseError::UnknownKey(k)),
+                    k => return Err(ParseHeaderError::UnknownKey(k)),
                 }
             }
             match (type_descriptor, fortran_order, shape) {
@@ -299,21 +299,21 @@ impl Header {
                     fortran_order: fortran_order,
                     shape: shape,
                 }),
-                (None, _, _) => Err(HeaderParseError::MissingKey("descr".to_owned())),
-                (_, None, _) => Err(HeaderParseError::MissingKey("fortran_order".to_owned())),
-                (_, _, None) => Err(HeaderParseError::MissingKey("shaper".to_owned())),
+                (None, _, _) => Err(ParseHeaderError::MissingKey("descr".to_owned())),
+                (_, None, _) => Err(ParseHeaderError::MissingKey("fortran_order".to_owned())),
+                (_, _, None) => Err(ParseHeaderError::MissingKey("shaper".to_owned())),
             }
         } else {
-            Err(HeaderParseError::MetaNotDict(value))
+            Err(ParseHeaderError::MetaNotDict(value))
         }
     }
 
-    pub fn from_reader<R: io::Read>(mut reader: R) -> Result<Self, HeaderReadError> {
+    pub fn from_reader<R: io::Read>(mut reader: R) -> Result<Self, ReadHeaderError> {
         // Check for magic string.
         let mut buf = vec![0; MAGIC_STRING.len()];
         reader.read_exact(&mut buf)?;
         if buf != MAGIC_STRING {
-            return Err(HeaderParseError::MagicString)?;
+            return Err(ParseHeaderError::MagicString)?;
         }
 
         // Get version number.
@@ -329,17 +329,17 @@ impl Header {
         reader.read_exact(&mut buf)?;
         let without_newline = match buf.split_last() {
             Some((&b'\n', rest)) => rest,
-            Some(_) | None => Err(HeaderParseError::MissingNewline)?,
+            Some(_) | None => Err(ParseHeaderError::MissingNewline)?,
         };
         let header_str = if without_newline.is_ascii() {
             unsafe { std::str::from_utf8_unchecked(without_newline) }
         } else {
-            return Err(HeaderParseError::NonAscii)?;
+            return Err(ParseHeaderError::NonAscii)?;
         };
         Ok(Header::from_py_value(
             header_str
                 .parse()
-                .map_err(|err| HeaderParseError::from(err))?,
+                .map_err(|err| ParseHeaderError::from(err))?,
         )?)
     }
 
@@ -406,7 +406,7 @@ impl Header {
         Ok(out)
     }
 
-    pub fn write<W: io::Write>(&self, mut writer: W) -> Result<(), HeaderWriteError> {
+    pub fn write<W: io::Write>(&self, mut writer: W) -> Result<(), WriteHeaderError> {
         let bytes = self.to_bytes()?;
         writer.write_all(&bytes)?;
         Ok(())

--- a/src/npy/mod.rs
+++ b/src/npy/mod.rs
@@ -1,7 +1,7 @@
 pub mod header;
 
 use self::header::{
-    FormatHeaderError, Header, HeaderParseError, HeaderReadError, HeaderWriteError,
+    FormatHeaderError, Header, ParseHeaderError, ReadHeaderError, WriteHeaderError,
 };
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
 use ndarray::prelude::*;
@@ -94,11 +94,11 @@ impl From<io::Error> for WriteNpyError {
     }
 }
 
-impl From<HeaderWriteError> for WriteNpyError {
-    fn from(err: HeaderWriteError) -> WriteNpyError {
+impl From<WriteHeaderError> for WriteNpyError {
+    fn from(err: WriteHeaderError) -> WriteNpyError {
         match err {
-            HeaderWriteError::Io(err) => WriteNpyError::Io(err),
-            HeaderWriteError::Format(err) => WriteNpyError::FormatHeader(err),
+            WriteHeaderError::Io(err) => WriteNpyError::Io(err),
+            WriteHeaderError::Format(err) => WriteNpyError::FormatHeader(err),
         }
     }
 }
@@ -262,7 +262,7 @@ pub enum ReadNpyError {
     /// An error caused by I/O.
     Io(io::Error),
     /// An error parsing the file header.
-    ParseHeader(HeaderParseError),
+    ParseHeader(ParseHeaderError),
     /// An error parsing the data.
     ParseData(Box<dyn Error + Send + Sync + 'static>),
     /// Overflow while computing the length of the array from the shape
@@ -323,17 +323,17 @@ impl From<io::Error> for ReadNpyError {
     }
 }
 
-impl From<HeaderReadError> for ReadNpyError {
-    fn from(err: HeaderReadError) -> ReadNpyError {
+impl From<ReadHeaderError> for ReadNpyError {
+    fn from(err: ReadHeaderError) -> ReadNpyError {
         match err {
-            HeaderReadError::Io(err) => ReadNpyError::Io(err),
-            HeaderReadError::Parse(err) => ReadNpyError::ParseHeader(err),
+            ReadHeaderError::Io(err) => ReadNpyError::Io(err),
+            ReadHeaderError::Parse(err) => ReadNpyError::ParseHeader(err),
         }
     }
 }
 
-impl From<HeaderParseError> for ReadNpyError {
-    fn from(err: HeaderParseError) -> ReadNpyError {
+impl From<ParseHeaderError> for ReadNpyError {
+    fn from(err: ParseHeaderError) -> ReadNpyError {
         ReadNpyError::ParseHeader(err)
     }
 }

--- a/src/npy/mod.rs
+++ b/src/npy/mod.rs
@@ -1,6 +1,6 @@
 pub mod header;
 
-use self::header::{FormatHeaderError, Header, HeaderReadError};
+use self::header::{FormatHeaderError, Header, HeaderParseError, HeaderReadError};
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
 use ndarray::prelude::*;
 use ndarray::{Data, DataOwned, IntoDimension};
@@ -10,18 +10,51 @@ use std::fmt;
 use std::io;
 use std::mem;
 
+/// An error writing array elements.
+#[derive(Debug)]
+pub enum WriteElementsError {
+    /// An error caused by I/O.
+    Io(io::Error),
+    /// An error formatting the elements.
+    FormatElements(Box<dyn Error + Send + Sync + 'static>),
+}
+
+impl Error for WriteElementsError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            WriteElementsError::Io(err) => Some(err),
+            WriteElementsError::FormatElements(err) => Some(&**err),
+        }
+    }
+}
+
+impl fmt::Display for WriteElementsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            WriteElementsError::Io(err) => write!(f, "I/O error: {}", err),
+            WriteElementsError::FormatElements(err) => {
+                write!(f, "error formatting data elements: {}", err)
+            }
+        }
+    }
+}
+
+impl From<io::Error> for WriteElementsError {
+    fn from(err: io::Error) -> WriteElementsError {
+        WriteElementsError::Io(err)
+    }
+}
+
 /// An array element type that can be written to an `.npy` or `.npz` file.
 pub unsafe trait WritableElement: Sized {
-    type Error: 'static + Error + Send + Sync;
-
     /// Returns a descriptor of the type that can be used in the header.
     fn type_descriptor() -> PyValue;
 
     /// Writes a single instance of `Self` to the writer.
-    fn write<W: io::Write>(&self, writer: W) -> Result<(), Self::Error>;
+    fn write<W: io::Write>(&self, writer: W) -> Result<(), WriteElementsError>;
 
     /// Writes a slice of `Self` to the writer.
-    fn write_slice<W: io::Write>(slice: &[Self], writer: W) -> Result<(), Self::Error>;
+    fn write_slice<W: io::Write>(slice: &[Self], writer: W) -> Result<(), WriteElementsError>;
 }
 
 /// An error writing a `.npy` file.
@@ -31,8 +64,8 @@ pub enum WriteNpyError {
     Io(io::Error),
     /// An error formatting the header.
     FormatHeader(FormatHeaderError),
-    /// An error issued by the element type when writing the data.
-    WritableElement(Box<dyn Error + Send + Sync>),
+    /// An error formatting the data elements.
+    FormatElements(Box<dyn Error + Send + Sync + 'static>),
 }
 
 impl Error for WriteNpyError {
@@ -40,7 +73,7 @@ impl Error for WriteNpyError {
         match self {
             WriteNpyError::Io(err) => Some(err),
             WriteNpyError::FormatHeader(err) => Some(err),
-            WriteNpyError::WritableElement(err) => Some(&**err),
+            WriteNpyError::FormatElements(err) => Some(&**err),
         }
     }
 }
@@ -50,7 +83,9 @@ impl fmt::Display for WriteNpyError {
         match self {
             WriteNpyError::Io(err) => write!(f, "I/O error: {}", err),
             WriteNpyError::FormatHeader(err) => write!(f, "error formatting header: {}", err),
-            WriteNpyError::WritableElement(err) => write!(f, "WritableElement error: {}", err),
+            WriteNpyError::FormatElements(err) => {
+                write!(f, "error formatting data elements: {}", err)
+            }
         }
     }
 }
@@ -64,6 +99,15 @@ impl From<io::Error> for WriteNpyError {
 impl From<FormatHeaderError> for WriteNpyError {
     fn from(err: FormatHeaderError) -> WriteNpyError {
         WriteNpyError::FormatHeader(err)
+    }
+}
+
+impl From<WriteElementsError> for WriteNpyError {
+    fn from(err: WriteElementsError) -> WriteNpyError {
+        match err {
+            WriteElementsError::Io(err) => WriteNpyError::Io(err),
+            WriteElementsError::FormatElements(err) => WriteNpyError::FormatElements(err),
+        }
     }
 }
 
@@ -113,8 +157,7 @@ where
             }
             .to_bytes()?;
             writer.write_all(&header)?;
-            A::write_slice(self.as_slice_memory_order().unwrap(), &mut writer)
-                .map_err(|err| WriteNpyError::WritableElement(Box::new(err)))?;
+            A::write_slice(self.as_slice_memory_order().unwrap(), &mut writer)?;
             Ok(())
         };
         if self.is_standard_layout() {
@@ -131,18 +174,75 @@ where
                 .to_bytes()?,
             )?;
             for elem in self.iter() {
-                elem.write(&mut writer)
-                    .map_err(|err| WriteNpyError::WritableElement(Box::new(err)))?;
+                elem.write(&mut writer)?;
             }
             Ok(())
         }
     }
 }
 
+/// An error reading array elements.
+#[derive(Debug)]
+pub enum ReadElementsError {
+    /// An error caused by I/O.
+    Io(io::Error),
+    /// The type descriptor does not match the element type.
+    WrongDescriptor(PyValue),
+    /// The file does not contain all the data described in the header.
+    MissingData,
+    /// Extra bytes are present between the end of the data and the end of the
+    /// file.
+    ExtraBytes(usize),
+    /// An error parsing the elements data.
+    ParseElements(Box<dyn Error + Send + Sync + 'static>),
+}
+
+impl Error for ReadElementsError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            ReadElementsError::Io(err) => Some(err),
+            ReadElementsError::WrongDescriptor(_) => None,
+            ReadElementsError::MissingData => None,
+            ReadElementsError::ExtraBytes(_) => None,
+            ReadElementsError::ParseElements(err) => Some(&**err),
+        }
+    }
+}
+
+impl fmt::Display for ReadElementsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ReadElementsError::Io(err) => write!(f, "I/O error: {}", err),
+            ReadElementsError::WrongDescriptor(desc) => {
+                write!(f, "incorrect descriptor ({}) for this type", desc)
+            }
+            ReadElementsError::MissingData => write!(f, "reached EOF before reading all data"),
+            ReadElementsError::ExtraBytes(num_extra_bytes) => {
+                write!(f, "file had {} extra bytes before EOF", num_extra_bytes)
+            }
+            ReadElementsError::ParseElements(err) => {
+                write!(f, "error parsing data elements: {}", err)
+            }
+        }
+    }
+}
+
+impl From<io::Error> for ReadElementsError {
+    /// Performs the conversion.
+    ///
+    /// If the error kind is `UnexpectedEof`, the `MissingData` variant is
+    /// returned. Otherwise, the `Io` variant is returned.
+    fn from(err: io::Error) -> ReadElementsError {
+        if err.kind() == io::ErrorKind::UnexpectedEof {
+            ReadElementsError::MissingData
+        } else {
+            ReadElementsError::Io(err)
+        }
+    }
+}
+
 /// An array element type that can be read from an `.npy` or `.npz` file.
 pub trait ReadableElement: Sized {
-    type Error: 'static + Error + Send + Sync;
-
     /// Reads to the end of the `reader`, creating a `Vec` of length `len`.
     ///
     /// This method should return `Err(_)` in at least the following cases:
@@ -154,36 +254,43 @@ pub trait ReadableElement: Sized {
         reader: R,
         type_desc: &PyValue,
         len: usize,
-    ) -> Result<Vec<Self>, Self::Error>;
+    ) -> Result<Vec<Self>, ReadElementsError>;
 }
 
 /// An error reading a `.npy` file.
 #[derive(Debug)]
 pub enum ReadNpyError {
-    /// An error caused by reading the file header.
-    Header(HeaderReadError),
-    /// An error issued by the element type when reading the data.
-    ///
-    /// Among other things, causes can include:
-    ///
-    /// * if the header type description does not match the element type
-    /// * if the reader has fewer elements than specified in the header
-    /// * if the reader has extra bytes after reading the data
-    ReadableElement(Box<dyn Error + Send + Sync>),
+    /// An error caused by I/O.
+    Io(io::Error),
+    /// An error parsing the file header.
+    ParseHeader(HeaderParseError),
+    /// An error parsing the elements.
+    ParseElements(Box<dyn Error + Send + Sync + 'static>),
     /// Overflow while computing the length of the array from the shape
     /// described in the file header.
     LengthOverflow,
     /// An error caused by incorrect `Dimension` type.
     WrongNdim(Option<usize>, usize),
+    /// The type descriptor does not match the element type.
+    WrongDescriptor(PyValue),
+    /// The file does not contain all the data described in the header.
+    MissingData,
+    /// Extra bytes are present between the end of the data and the end of the
+    /// file.
+    ExtraBytes(usize),
 }
 
 impl Error for ReadNpyError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            ReadNpyError::Header(err) => Some(err),
-            ReadNpyError::ReadableElement(err) => Some(&**err),
+            ReadNpyError::Io(err) => Some(err),
+            ReadNpyError::ParseHeader(err) => Some(err),
+            ReadNpyError::ParseElements(err) => Some(&**err),
             ReadNpyError::LengthOverflow => None,
             ReadNpyError::WrongNdim(_, _) => None,
+            ReadNpyError::WrongDescriptor(_) => None,
+            ReadNpyError::MissingData => None,
+            ReadNpyError::ExtraBytes(_) => None,
         }
     }
 }
@@ -191,27 +298,56 @@ impl Error for ReadNpyError {
 impl fmt::Display for ReadNpyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ReadNpyError::Header(err) => write!(f, "error reading header: {}", err),
-            ReadNpyError::ReadableElement(err) => write!(f, "ReadableElement error: {}", err),
+            ReadNpyError::Io(err) => write!(f, "I/O error: {}", err),
+            ReadNpyError::ParseHeader(err) => write!(f, "error parsing header: {}", err),
+            ReadNpyError::ParseElements(err) => write!(f, "error parsing data elements: {}", err),
             ReadNpyError::LengthOverflow => write!(f, "overflow computing length from shape"),
             ReadNpyError::WrongNdim(expected, actual) => write!(
                 f,
                 "ndim {} of array did not match Dimension type with NDIM = {:?}",
                 actual, expected
             ),
+            ReadNpyError::WrongDescriptor(desc) => {
+                write!(f, "incorrect descriptor ({}) for this type", desc)
+            }
+            ReadNpyError::MissingData => write!(f, "reached EOF before reading all data"),
+            ReadNpyError::ExtraBytes(num_extra_bytes) => {
+                write!(f, "file had {} extra bytes before EOF", num_extra_bytes)
+            }
         }
+    }
+}
+
+impl From<io::Error> for ReadNpyError {
+    fn from(err: io::Error) -> ReadNpyError {
+        ReadNpyError::Io(err)
     }
 }
 
 impl From<HeaderReadError> for ReadNpyError {
     fn from(err: HeaderReadError) -> ReadNpyError {
-        ReadNpyError::Header(err)
+        match err {
+            HeaderReadError::Io(err) => ReadNpyError::Io(err),
+            HeaderReadError::Parse(err) => ReadNpyError::ParseHeader(err),
+        }
     }
 }
 
-impl From<ReadPrimitiveError> for ReadNpyError {
-    fn from(err: ReadPrimitiveError) -> ReadNpyError {
-        ReadNpyError::ReadableElement(Box::new(err))
+impl From<HeaderParseError> for ReadNpyError {
+    fn from(err: HeaderParseError) -> ReadNpyError {
+        ReadNpyError::ParseHeader(err)
+    }
+}
+
+impl From<ReadElementsError> for ReadNpyError {
+    fn from(err: ReadElementsError) -> ReadNpyError {
+        match err {
+            ReadElementsError::Io(err) => ReadNpyError::Io(err),
+            ReadElementsError::WrongDescriptor(desc) => ReadNpyError::WrongDescriptor(desc),
+            ReadElementsError::MissingData => ReadNpyError::MissingData,
+            ReadElementsError::ExtraBytes(nbytes) => ReadNpyError::ExtraBytes(nbytes),
+            ReadElementsError::ParseElements(err) => ReadNpyError::ParseElements(err),
+        }
     }
 }
 
@@ -260,8 +396,7 @@ where
             Some(len) if len <= std::isize::MAX as usize => len,
             _ => return Err(ReadNpyError::LengthOverflow),
         };
-        let data = A::read_to_end_exact_vec(&mut reader, &header.type_descriptor, len)
-            .map_err(|err| ReadNpyError::ReadableElement(Box::new(err)))?;
+        let data = A::read_to_end_exact_vec(&mut reader, &header.type_descriptor, len)?;
         ArrayBase::from_shape_vec(shape.set_f(header.fortran_order), data)
             .unwrap()
             .into_dimensionality()
@@ -272,8 +407,6 @@ where
 macro_rules! impl_writable_primitive {
     ($elem:ty, $little_desc:expr, $big_desc:expr) => {
         unsafe impl WritableElement for $elem {
-            type Error = io::Error;
-
             fn type_descriptor() -> PyValue {
                 if cfg!(target_endian = "little") {
                     PyValue::String($little_desc.into())
@@ -284,7 +417,7 @@ macro_rules! impl_writable_primitive {
                 }
             }
 
-            fn write<W: io::Write>(&self, mut writer: W) -> Result<(), Self::Error> {
+            fn write<W: io::Write>(&self, mut writer: W) -> Result<(), WriteElementsError> {
                 // Function to ensure lifetime of bytes slice is correct.
                 fn cast(self_: &$elem) -> &[u8] {
                     unsafe {
@@ -294,10 +427,14 @@ macro_rules! impl_writable_primitive {
                         )
                     }
                 }
-                writer.write_all(cast(self))
+                writer.write_all(cast(self))?;
+                Ok(())
             }
 
-            fn write_slice<W: io::Write>(slice: &[Self], mut writer: W) -> Result<(), Self::Error> {
+            fn write_slice<W: io::Write>(
+                slice: &[Self],
+                mut writer: W,
+            ) -> Result<(), WriteElementsError> {
                 // Function to ensure lifetime of bytes slice is correct.
                 fn cast(slice: &[$elem]) -> &[u8] {
                     unsafe {
@@ -307,90 +444,34 @@ macro_rules! impl_writable_primitive {
                         )
                     }
                 }
-                writer.write_all(cast(slice))
+                writer.write_all(cast(slice))?;
+                Ok(())
             }
         }
     };
-}
-
-/// An error reading a primitive element.
-#[derive(Debug)]
-pub enum ReadPrimitiveError {
-    /// The type descriptor does not match the element type.
-    BadDescriptor(PyValue),
-    /// One of the values of the elements in the data is invalid for the
-    /// element type.
-    BadValue,
-    /// The file does not contain all the data described in the header.
-    MissingData,
-    /// Extra bytes are present between the end of the data and the end of the
-    /// file.
-    ExtraBytes(usize),
-    /// An error caused by I/O.
-    Io(io::Error),
-}
-
-impl Error for ReadPrimitiveError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            ReadPrimitiveError::BadDescriptor(_) => None,
-            ReadPrimitiveError::BadValue => None,
-            ReadPrimitiveError::MissingData => None,
-            ReadPrimitiveError::ExtraBytes(_) => None,
-            ReadPrimitiveError::Io(err) => Some(err),
-        }
-    }
-}
-
-impl fmt::Display for ReadPrimitiveError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            ReadPrimitiveError::BadDescriptor(desc) => {
-                write!(f, "bad descriptor for this type: {}", desc)
-            }
-            ReadPrimitiveError::BadValue => write!(f, "invalid value for this type"),
-            ReadPrimitiveError::MissingData => write!(f, "reached EOF before reading all data"),
-            ReadPrimitiveError::ExtraBytes(num_extra_bytes) => {
-                write!(f, "file had {} extra bytes before EOF", num_extra_bytes)
-            }
-            ReadPrimitiveError::Io(err) => write!(f, "I/O error: {}", err),
-        }
-    }
-}
-
-impl From<io::Error> for ReadPrimitiveError {
-    fn from(err: io::Error) -> ReadPrimitiveError {
-        if err.kind() == io::ErrorKind::UnexpectedEof {
-            ReadPrimitiveError::MissingData
-        } else {
-            ReadPrimitiveError::Io(err)
-        }
-    }
 }
 
 /// Returns `Ok(_)` iff the `reader` had no more bytes on entry to this
 /// function.
 ///
 /// **Warning** This will consume the remainder of the reader.
-pub fn check_for_extra_bytes<R: io::Read>(reader: &mut R) -> Result<(), ReadPrimitiveError> {
+pub fn check_for_extra_bytes<R: io::Read>(reader: &mut R) -> Result<(), ReadElementsError> {
     let num_extra_bytes = reader.read_to_end(&mut Vec::new())?;
     if num_extra_bytes == 0 {
         Ok(())
     } else {
-        Err(ReadPrimitiveError::ExtraBytes(num_extra_bytes))
+        Err(ReadElementsError::ExtraBytes(num_extra_bytes))
     }
 }
 
 macro_rules! impl_readable_primitive_one_byte {
     ($elem:ty, [$($desc:expr),*], $zero:expr, $read_into:ident) => {
         impl ReadableElement for $elem {
-            type Error = ReadPrimitiveError;
-
             fn read_to_end_exact_vec<R: io::Read>(
                 mut reader: R,
                 type_desc: &PyValue,
                 len: usize,
-            ) -> Result<Vec<Self>, Self::Error> {
+            ) -> Result<Vec<Self>, ReadElementsError> {
                 match *type_desc {
                     PyValue::String(ref s) if $(s == $desc)||* => {
                         let mut out = vec![$zero; len];
@@ -398,7 +479,7 @@ macro_rules! impl_readable_primitive_one_byte {
                         check_for_extra_bytes(&mut reader)?;
                         Ok(out)
                     }
-                    ref other => Err(ReadPrimitiveError::BadDescriptor(other.clone())),
+                    ref other => Err(ReadElementsError::WrongDescriptor(other.clone())),
                 }
             }
         }
@@ -418,13 +499,11 @@ impl_primitive_one_byte!(u8, "|u1", ["|u1", "u1", "B"], 0, read_exact);
 macro_rules! impl_readable_primitive_multi_byte {
     ($elem:ty, $little_desc:expr, $big_desc:expr, $zero:expr, $read_into:ident) => {
         impl ReadableElement for $elem {
-            type Error = ReadPrimitiveError;
-
             fn read_to_end_exact_vec<R: io::Read>(
                 mut reader: R,
                 type_desc: &PyValue,
                 len: usize,
-            ) -> Result<Vec<Self>, Self::Error> {
+            ) -> Result<Vec<Self>, ReadElementsError> {
                 let mut out = vec![$zero; len];
                 match *type_desc {
                     PyValue::String(ref s) if s == $little_desc => {
@@ -434,7 +513,7 @@ macro_rules! impl_readable_primitive_multi_byte {
                         reader.$read_into::<BigEndian>(&mut out)?;
                     }
                     ref other => {
-                        return Err(ReadPrimitiveError::BadDescriptor(other.clone()));
+                        return Err(ReadElementsError::WrongDescriptor(other.clone()));
                     }
                 }
                 check_for_extra_bytes(&mut reader)?;
@@ -462,14 +541,36 @@ impl_primitive_multi_byte!(u64, "<u8", ">u8", 0, read_u64_into);
 impl_primitive_multi_byte!(f32, "<f4", ">f4", 0., read_f32_into);
 impl_primitive_multi_byte!(f64, "<f8", ">f8", 0., read_f64_into);
 
-impl ReadableElement for bool {
-    type Error = ReadPrimitiveError;
+/// An error parsing a `bool` from a byte.
+#[derive(Debug)]
+struct ParseBoolError {
+    bad_value: u8,
+}
 
+impl Error for ParseBoolError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+}
+
+impl fmt::Display for ParseBoolError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "error parsing value {:#04x} as a bool", self.bad_value)
+    }
+}
+
+impl From<ParseBoolError> for ReadElementsError {
+    fn from(err: ParseBoolError) -> ReadElementsError {
+        ReadElementsError::ParseElements(Box::new(err))
+    }
+}
+
+impl ReadableElement for bool {
     fn read_to_end_exact_vec<R: io::Read>(
         mut reader: R,
         type_desc: &PyValue,
         len: usize,
-    ) -> Result<Vec<Self>, Self::Error> {
+    ) -> Result<Vec<Self>, ReadElementsError> {
         match *type_desc {
             PyValue::String(ref s) if s == "|b1" => {
                 // Read the data.
@@ -483,7 +584,7 @@ impl ReadableElement for bool {
                 // represented as `0x01`.
                 for &byte in &bytes {
                     if byte > 1 {
-                        return Err(ReadPrimitiveError::BadValue);
+                        return Err(ReadElementsError::from(ParseBoolError { bad_value: byte }));
                     }
                 }
 
@@ -507,7 +608,7 @@ impl ReadableElement for bool {
                     Ok(unsafe { Vec::from_raw_parts(ptr as *mut bool, len, cap) })
                 }
             }
-            ref other => Err(ReadPrimitiveError::BadDescriptor(other.clone())),
+            ref other => Err(ReadElementsError::WrongDescriptor(other.clone())),
         }
     }
 }
@@ -519,7 +620,7 @@ impl_writable_primitive!(bool, "|b1", "|b1");
 
 #[cfg(test)]
 mod test {
-    use super::{ReadPrimitiveError, ReadableElement};
+    use super::{ReadElementsError, ReadableElement};
     use py_literal::Value as PyValue;
     use std::io::Cursor;
 
@@ -536,7 +637,9 @@ mod test {
         let data = &[0x00, 0x01, 0x05, 0x00, 0x01];
         let type_desc = PyValue::String(String::from("|b1"));
         match <bool>::read_to_end_exact_vec(Cursor::new(data), &type_desc, data.len()) {
-            Err(ReadPrimitiveError::BadValue) => {}
+            Err(ReadElementsError::ParseElements(err)) => {
+                assert_eq!(format!("{}", err), "error parsing value 0x05 as a bool");
+            }
             _ => panic!(),
         }
     }

--- a/src/npy/mod.rs
+++ b/src/npy/mod.rs
@@ -132,13 +132,10 @@ impl From<WriteDataError> for WriteNpyError {
 /// use std::fs::File;
 /// # use ndarray_npy::WriteNpyError;
 ///
-/// # fn write_example() -> Result<(), WriteNpyError> {
 /// let arr: Array2<i32> = array![[1, 2, 3], [4, 5, 6]];
 /// let writer = File::create("array.npy")?;
 /// arr.write_npy(writer)?;
-/// # Ok(())
-/// # }
-/// # fn main () {}
+/// # Ok::<_, WriteNpyError>(())
 /// ```
 pub trait WriteNpyExt {
     /// Writes the array to `writer` in [`.npy`
@@ -365,14 +362,12 @@ impl From<ReadDataError> for ReadNpyError {
 /// use ndarray::prelude::*;
 /// use ndarray_npy::ReadNpyExt;
 /// use std::fs::File;
+/// # use ndarray_npy::ReadNpyError;
 ///
-/// # fn read_example() -> Result<(), Box<std::error::Error>> {
 /// let reader = File::open("array.npy")?;
 /// let arr = Array2::<i32>::read_npy(reader)?;
 /// # println!("arr = {}", arr);
-/// # Ok(())
-/// # }
-/// # fn main () {}
+/// # Ok::<_, ReadNpyError>(())
 /// ```
 pub trait ReadNpyExt: Sized {
     /// Reads the array from `reader` in [`.npy`

--- a/src/npy/mod.rs
+++ b/src/npy/mod.rs
@@ -123,11 +123,7 @@ impl From<WriteDataError> for WriteNpyError {
 /// # Example
 ///
 /// ```
-/// #[macro_use]
-/// extern crate ndarray;
-/// extern crate ndarray_npy;
-///
-/// use ndarray::prelude::*;
+/// use ndarray::{array, Array2};
 /// use ndarray_npy::WriteNpyExt;
 /// use std::fs::File;
 /// # use ndarray_npy::WriteNpyError;
@@ -355,11 +351,7 @@ impl From<ReadDataError> for ReadNpyError {
 /// # Example
 ///
 /// ```
-/// #[macro_use]
-/// extern crate ndarray;
-/// extern crate ndarray_npy;
-///
-/// use ndarray::prelude::*;
+/// use ndarray::Array2;
 /// use ndarray_npy::ReadNpyExt;
 /// use std::fs::File;
 /// # use ndarray_npy::ReadNpyError;

--- a/src/npz.rs
+++ b/src/npz.rs
@@ -54,11 +54,7 @@ impl From<WriteNpyError> for WriteNpzError {
 /// # Example
 ///
 /// ```
-/// #[macro_use]
-/// extern crate ndarray;
-/// extern crate ndarray_npy;
-///
-/// use ndarray::prelude::*;
+/// use ndarray::{array, Array1, Array2};
 /// use ndarray_npy::NpzWriter;
 /// use std::fs::File;
 ///
@@ -161,11 +157,7 @@ impl From<ReadNpyError> for ReadNpzError {
 /// # Example
 ///
 /// ```
-/// #[macro_use]
-/// extern crate ndarray;
-/// extern crate ndarray_npy;
-///
-/// use ndarray::prelude::*;
+/// use ndarray::{Array1, Array2};
 /// use ndarray_npy::NpzReader;
 /// use std::fs::File;
 ///

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -1,6 +1,3 @@
-extern crate ndarray;
-extern crate ndarray_npy;
-
 use ndarray::prelude::*;
 use ndarray_npy::{ReadNpyExt, WriteNpyExt};
 use std::io::Cursor;

--- a/tests/round_trip.rs
+++ b/tests/round_trip.rs
@@ -1,6 +1,3 @@
-extern crate ndarray;
-extern crate ndarray_npy;
-
 use ndarray::prelude::*;
 use ndarray::{array, Data};
 use ndarray_npy::{ReadNpyExt, ReadableElement, WritableElement, WriteNpyExt};


### PR DESCRIPTION
The primary motivation is combining `Io` errors into a single variant in `Read/WriteNpyError`.