### PR TITLE
Add .finish() method to NpzWriter

### DIFF
--- a/examples/simple_npz.rs
+++ b/examples/simple_npz.rs
@@ -8,6 +8,7 @@ fn write_example() -> Result<(), Box<dyn std::error::Error>> {
     let b: Array1<i32> = array![7, 8, 9];
     npz.add_array("a", &a)?;
     npz.add_array("b", &b)?;
+    npz.finish()?;
     Ok(())
 }
 


### PR DESCRIPTION
A couple of decisions to make:

- Should `.finish()` call `.flush()`, or if it would be better for the user to call `.finish()?.flush()?`?
- Should `.finish()` take `self` or `&mut self`?