### PR TITLE
Fix branch name and cross_test job for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Continuous integration
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,9 @@ jobs:
       - name: Install cross
         run: cargo install cross -f
       - name: Build
-        run: cargo build --verbose --target=${{ matrix.target }}
+        run: cross build --verbose --target=${{ matrix.target }}
       - name: Run tests
-        run: cargo test --verbose --target=${{ matrix.target }}
+        run: cross test --verbose --target=${{ matrix.target }}
 
   clippy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Using `$default-branch` doesn't work. (The action is not triggered.) So, this PR sets the branch name manually.

The `cross_test` job was broken. This PR fixes it to use `cross` where appropriate instead of `cargo`.