### PR TITLE
Add MIPS64 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,13 @@ jobs:
     strategy:
       matrix:
         include:
+          # 64-bit, big-endian
+          - rust: stable
+            target: mips64-unknown-linux-gnuabi64
+          # 32-bit, big-endian
           - rust: stable
             target: mips-unknown-linux-gnu
+          # 32-bit, little-endian
           - rust: stable
             target: i686-unknown-linux-gnu
     steps:


### PR DESCRIPTION
With this addition, CI tests all combinations of 32/64-bit and little/big-endian.