### PR TITLE
Add zstd-compressed archives support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ zip = { version = "0.6.3", default-features = false, optional = true }
 default = ["compressed_npz", "num-complex-0_4"]
 npz = ["zip"]
 compressed_npz = ["npz", "zip/deflate"]
-compressed_npz_zstd = ["npz", "zip/zstd"]
 
 [dev-dependencies]
 memmap2 = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ zip = { version = "0.6.3", default-features = false, optional = true }
 default = ["compressed_npz", "num-complex-0_4"]
 npz = ["zip"]
 compressed_npz = ["npz", "zip/deflate"]
+compressed_npz_zstd = ["npz", "zip/zstd"]
 
 [dev-dependencies]
 memmap2 = "0.2"

--- a/src/npz.rs
+++ b/src/npz.rs
@@ -103,16 +103,15 @@ impl<W: Write + Seek> NpzWriter<W> {
         }
     }
 
-    // TODO: it makes sense to add support for bzip2 also
-    // this necessitates some more generic API, as having three functions is janky... =)
-
-    /// Creates a new `.npz` file with zstd compression. While it is not directly supported by numpy,
-    /// it still could be useful (also it is possible to monkey-patch numpy to support it).
-    #[cfg(feature = "compressed_npz_zstd")]
-    pub fn new_zstd_compressed(writer: W, level: Option<i32>) -> NpzWriter<W> {
+    /// Creates a new `.npz` file with the specified options.
+    ///
+    /// This allows you to use a custom compression method, such as [`CompressionMethod::Zstd`] or set other options.
+    ///
+    /// Make sure to enable the `zstd` feature of the `zip` crate to use [`CompressionMethod::Zstd`] or other relevant features.
+    pub fn new_with_options(writer: W, options: FileOptions) -> NpzWriter<W> {
         NpzWriter {
             zip: ZipWriter::new(writer),
-            options: FileOptions::default().compression_method(CompressionMethod::ZSTD).compression_level(level),
+            options,
         }
     }
 

--- a/src/npz.rs
+++ b/src/npz.rs
@@ -103,6 +103,19 @@ impl<W: Write + Seek> NpzWriter<W> {
         }
     }
 
+    // TODO: it makes sense to add support for bzip2 also
+    // this necessitates some more generic API, as having three functions is janky... =)
+
+    /// Creates a new `.npz` file with zstd compression. While it is not directly supported by numpy,
+    /// it still could be useful (also it is possible to monkey-patch numpy to support it).
+    #[cfg(feature = "compressed_npz_zstd")]
+    pub fn new_zstd_compressed(writer: W, level: Option<i32>) -> NpzWriter<W> {
+        NpzWriter {
+            zip: ZipWriter::new(writer),
+            options: FileOptions::default().compression_method(CompressionMethod::ZSTD).compression_level(level),
+        }
+    }
+
     /// Adds an array with the specified `name` to the `.npz` file.
     ///
     /// Note that a `.npy` extension will be appended to `name`; this matches NumPy's behavior.


### PR DESCRIPTION
zstd can offer compression rates/speed much superior to standard deflate used in zip. 

zip files, which npz is based on, already have a standard way to use zstd compression, so this PR just utilizes this way.

It should be noted that python stdlib (and, hence, `numpy`),  doesn't yet support this compression scheme, but support can be hacked in with this monkeypatch (requires `zipfile_zstd` package):

```python
def numpy_zstd_monkeypatch():
	"""
	monkey patch numpy to support zstd for npz files
	"""
	import numpy as np
	from numpy.compat import os_fspath

	def zipfile_factory(file, *args, **kwargs):
		"""
		Create a ZipFile.
		Allows for Zip64, and the `file` argument can accept file, str, or
		pathlib.Path objects. `args` and `kwargs` are passed to the zipfile.ZipFile
		constructor.
		"""
		if not hasattr(file, 'read'):
			file = os_fspath(file)
		import zipfile_zstd as zipfile
		kwargs['allowZip64'] = True
		return zipfile.ZipFile(file, *args, **kwargs)

	np.lib.npyio.zipfile_factory = zipfile_factory
```