### PR TITLE
Match NumPy regarding .npy for names in .npz files

### DIFF
--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -6,6 +6,8 @@ use std::io::{self, Read};
 use std::ops::{Deref, DerefMut};
 
 mod examples;
+#[cfg(feature = "npz")]
+mod npz;
 mod primitive;
 mod round_trip;
 

--- a/tests/integration/npz.rs
+++ b/tests/integration/npz.rs
@@ -1,0 +1,52 @@
+//! .npz examples.
+
+use ndarray::{array, Array2};
+use ndarray_npy::{NpzReader, NpzWriter};
+use std::{error::Error, io::Cursor};
+
+#[test]
+fn round_trip_npz() -> Result<(), Box<dyn Error>> {
+    let mut buf = Vec::<u8>::new();
+
+    let arr1 = array![[1i32, 3, 0], [4, 7, -1]];
+    let arr2 = array![[9i32, 6], [-5, 2], [3, -1]];
+
+    {
+        let mut writer = NpzWriter::new(Cursor::new(&mut buf));
+        writer.add_array("arr1", &arr1)?;
+        writer.add_array("arr2", &arr2)?;
+        writer.finish()?;
+    }
+
+    {
+        let mut reader = NpzReader::new(Cursor::new(&buf))?;
+        assert!(!reader.is_empty());
+        assert_eq!(reader.len(), 2);
+        assert_eq!(
+            reader.names()?,
+            vec!["arr1".to_string(), "arr2".to_string()],
+        );
+        {
+            let by_name: Array2<i32> = reader.by_name("arr1")?;
+            assert_eq!(by_name, arr1);
+        }
+        {
+            let by_name: Array2<i32> = reader.by_name("arr1.npy")?;
+            assert_eq!(by_name, arr1);
+        }
+        {
+            let by_name: Array2<i32> = reader.by_name("arr2")?;
+            assert_eq!(by_name, arr2);
+        }
+        {
+            let by_name: Array2<i32> = reader.by_name("arr2.npy")?;
+            assert_eq!(by_name, arr2);
+        }
+        {
+            let res: Result<Array2<i32>, _> = reader.by_name("arr1.npy.npy");
+            assert!(res.is_err());
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #48.

When writing a .npz file, NumPy unconditionally adds ".npy" to every name. When generating the public list of names when reading a .npz file, NumPy strips a single ".npy" (if present) from each name. When accessing an array in a .npz file by name, it first checks if that exact name is in the .npz file, and if not, it then tries the name with ".npy" appended. While I personally dislike the inconsistency/implicitness of this behavior, ndarray-npy should follow it for compatibility with NumPy.