### PR TITLE
Make npy public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //!
 //! [header dictionary]: https://docs.scipy.org/doc/numpy/reference/generated/numpy.lib.format.html#format-version-1-0
 
-mod npy;
+pub mod npy;
 #[cfg(feature = "npz")]
 mod npz;
 


### PR DESCRIPTION
Allow to parse Header before loading npz archive. Making npy public gives access to npy.header.Header that otherwise is not exposed